### PR TITLE
Don't explicitly try to reconnect suspended client

### DIFF
--- a/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/MainActivity.java
+++ b/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/MainActivity.java
@@ -159,10 +159,10 @@ public class MainActivity extends ActionBarActivity implements
 
     @Override
     public void onConnectionSuspended(int cause) {
-        // The connection to Google Play services was lost for some reason. We call connect() to
-        // attempt to re-establish the connection.
+        // The connection to Google Play services was lost for some reason. 
         Log.i(TAG, "Connection suspended");
-        mGoogleApiClient.connect();
+        
+        // onConnected() will be called again automatically when the service reconnects
     }
 
     /**


### PR DESCRIPTION
When onConnectionSuspended() is called by Google Play Services client, I believe it is not necessary to call mGooglePlayClient.connect() to attempt reconnection.  This should be handled automatically by the Google Play Services API.

This was confirmed by the original author of GoogleApiClient on this web page:
http://stackoverflow.com/questions/26056148/googleapiclient-onconnectionsuspended-should-i-call-mgoogleapiclient-connect