### PR TITLE
No need to call connect() when Suspended

### DIFF
--- a/ActivityRecognition/app/src/main/java/com/google/android/gms/location/sample/activityrecognition/MainActivity.java
+++ b/ActivityRecognition/app/src/main/java/com/google/android/gms/location/sample/activityrecognition/MainActivity.java
@@ -196,7 +196,8 @@ public class MainActivity extends ActionBarActivity implements
         // The connection to Google Play services was lost for some reason. We call connect() to
         // attempt to re-establish the connection.
         Log.i(TAG, "Connection suspended");
-        mGoogleApiClient.connect();
+        // The GoogleAPIClient will re-connect automatically. No need to call it.
+        // mGoogleApiClient.connect(); 
     }
 
     /**


### PR DESCRIPTION
Based on the discussion here (http://stackoverflow.com/questions/26056148/googleapiclient-onconnectionsuspended-should-i-call-mgoogleapiclient-connect/26147518#26147518), not need to call connect in onConnectionSuspended(). The google API client will call it automatically.
