### PR TITLE
In Android O, some IntentServices will not trigger if the app has bee…

### DIFF
--- a/Geofencing/app/src/main/AndroidManifest.xml
+++ b/Geofencing/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@ limitations under the License.
     package="com.google.android.gms.location.sample.geofencing">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
         android:allowBackup="true"

--- a/Geofencing/app/src/main/AndroidManifest.xml
+++ b/Geofencing/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
 Copyright 2014 Google, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.android.gms.location.sample.geofencing" >
+    package="com.google.android.gms.location.sample.geofencing">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
@@ -23,14 +22,14 @@ limitations under the License.
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.Base" >
+        android:theme="@style/Theme.Base">
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />
 
         <activity
             android:name=".MainActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -38,6 +37,14 @@ limitations under the License.
             </intent-filter>
         </activity>
 
-        <service android:name=".GeofenceTransitionsIntentService" />
+        <receiver
+            android:name=".GeofenceBroadcastReceiver"
+            android:enabled="true"
+            android:exported="true" />
+
+        <service
+            android:name=".GeofenceTransitionsJobIntentService"
+            android:exported="true"
+            android:permission="android.permission.BIND_JOB_SERVICE" />
     </application>
 </manifest>

--- a/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/Constants.java
+++ b/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/Constants.java
@@ -16,6 +16,7 @@
 
 package com.google.android.gms.location.sample.geofencing;
 
+import com.google.android.gms.location.Geofence;
 import com.google.android.gms.maps.model.LatLng;
 
 import java.util.HashMap;
@@ -42,8 +43,8 @@ final class Constants {
     /**
      * For this sample, geofences expire after twelve hours.
      */
-    static final long GEOFENCE_EXPIRATION_IN_MILLISECONDS =
-            GEOFENCE_EXPIRATION_IN_HOURS * 60 * 60 * 1000;
+    static final long GEOFENCE_EXPIRATION_IN_MILLISECONDS = Geofence.NEVER_EXPIRE;
+            //GEOFENCE_EXPIRATION_IN_HOURS * 60 * 60 * 1000;
     static final float GEOFENCE_RADIUS_IN_METERS = 1609; // 1 mile, 1.6 km
 
     /**

--- a/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/Constants.java
+++ b/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/Constants.java
@@ -16,7 +16,6 @@
 
 package com.google.android.gms.location.sample.geofencing;
 
-import com.google.android.gms.location.Geofence;
 import com.google.android.gms.maps.model.LatLng;
 
 import java.util.HashMap;
@@ -43,8 +42,8 @@ final class Constants {
     /**
      * For this sample, geofences expire after twelve hours.
      */
-    static final long GEOFENCE_EXPIRATION_IN_MILLISECONDS = Geofence.NEVER_EXPIRE;
-            //GEOFENCE_EXPIRATION_IN_HOURS * 60 * 60 * 1000;
+    static final long GEOFENCE_EXPIRATION_IN_MILLISECONDS =
+            GEOFENCE_EXPIRATION_IN_HOURS * 60 * 60 * 1000;
     static final float GEOFENCE_RADIUS_IN_METERS = 1609; // 1 mile, 1.6 km
 
     /**

--- a/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/GeofenceBroadcastReceiver.java
+++ b/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/GeofenceBroadcastReceiver.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.android.gms.location.sample.geofencing;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Receiver for geofence transition changes.
+ * <p>
+ * Receives geofence transition events from Location Services in the form of an Intent containing
+ * the transition type and geofence id(s) that triggered the transition. Creates a JobIntentService
+ * that will handle the intent in the background.
+ */
+public class GeofenceBroadcastReceiver extends BroadcastReceiver {
+
+    /**
+     * Receives incoming intents.
+     *
+     * @param context the application context.
+     * @param intent  sent by Location Services. This Intent is provided to Location
+     *                Services (inside a PendingIntent) when addGeofences() is called.
+     */
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        // Enqueues a JobIntentService passing the context and intent as parameters
+        GeofenceTransitionsJobIntentService.enqueueWork(context, intent);
+    }
+}

--- a/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/GeofenceTransitionsJobIntentService.java
+++ b/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/GeofenceTransitionsJobIntentService.java
@@ -16,7 +16,6 @@
 
 package com.google.android.gms.location.sample.geofencing;
 
-import android.app.IntentService;
 import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
@@ -25,6 +24,7 @@ import android.content.Intent;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.os.Build;
+import android.support.v4.app.JobIntentService;
 import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.TaskStackBuilder;
 import android.text.TextUtils;
@@ -43,19 +43,19 @@ import java.util.List;
  * the transition type and geofence id(s) that triggered the transition. Creates a notification
  * as the output.
  */
-public class GeofenceTransitionsIntentService extends IntentService {
+public class GeofenceTransitionsJobIntentService extends JobIntentService {
+
+    private static final int JOB_ID = 573;
 
     private static final String TAG = "GeofenceTransitionsIS";
 
     private static final String CHANNEL_ID = "channel_01";
 
     /**
-     * This constructor is required, and calls the super IntentService(String)
-     * constructor with the name for a worker thread.
+     * Convenience method for enqueuing work in to this service.
      */
-    public GeofenceTransitionsIntentService() {
-        // Use the TAG to name the worker thread.
-        super(TAG);
+    public static void enqueueWork(Context context, Intent intent) {
+        enqueueWork(context, GeofenceTransitionsJobIntentService.class, JOB_ID, intent);
     }
 
     /**
@@ -64,7 +64,7 @@ public class GeofenceTransitionsIntentService extends IntentService {
      *               Services (inside a PendingIntent) when addGeofences() is called.
      */
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(Intent intent) {
         GeofencingEvent geofencingEvent = GeofencingEvent.fromIntent(intent);
         if (geofencingEvent.hasError()) {
             String errorMessage = GeofenceErrorMessages.getErrorString(this,

--- a/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/MainActivity.java
+++ b/Geofencing/app/src/main/java/com/google/android/gms/location/sample/geofencing/MainActivity.java
@@ -230,10 +230,11 @@ public class MainActivity extends AppCompatActivity implements OnCompleteListene
         if (mGeofencePendingIntent != null) {
             return mGeofencePendingIntent;
         }
-        Intent intent = new Intent(this, GeofenceTransitionsIntentService.class);
+        Intent intent = new Intent(this, GeofenceBroadcastReceiver.class);
         // We use FLAG_UPDATE_CURRENT so that we get the same pending intent back when calling
         // addGeofences() and removeGeofences().
-        return PendingIntent.getService(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        mGeofencePendingIntent = PendingIntent.getBroadcast(this, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return mGeofencePendingIntent;
     }
 
     /**


### PR DESCRIPTION
…n stopped. To fix this we do the following:

- Add a BroadcastReceiver that will receive the intent and call a JobIntentService to handle the intent
- Use JobIntentService (Added for Android O), instead of IntentService
- Set the geofence to never expire
- For pendingIntent, we getBroadcast instead of getService