### PR TITLE
Add google maven repo to common build.gradle repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
         mavenLocal()
     }


### PR DESCRIPTION
ActivityRecognition-app is not able to find `com.google.android.gms:play-services-location:11.4.0` because the google maven repo is not added.