### PR TITLE
Fixed Issue# 195 and other errors that were causing initial build issues after cloning repo

### DIFF
--- a/BasicLocationSample/kotlin/app/src/main/java/com/google/android/gms/location/sample/basiclocationsample/MainActivity.kt
+++ b/BasicLocationSample/kotlin/app/src/main/java/com/google/android/gms/location/sample/basiclocationsample/MainActivity.kt
@@ -85,11 +85,12 @@ class MainActivity : AppCompatActivity() {
     private fun getLastLocation() {
         fusedLocationClient.lastLocation
                 .addOnCompleteListener(this) { task ->
-                    if (task.isSuccessful && task.result != null) {
+                    val mLastLocation = task.result
+                    if (task.isSuccessful && mLastLocation != null) {
                         latitudeText.text = resources
-                                .getString(R.string.latitude_label, task.result.latitude)
+                                .getString(R.string.latitude_label, mLastLocation.latitude)
                         longitudeText.text = resources
-                                .getString(R.string.longitude_label, task.result.longitude)
+                                .getString(R.string.longitude_label, mLastLocation.longitude)
                     } else {
                         Log.w(TAG, "getLastLocation:exception", task.exception)
                         showSnackbar(R.string.no_location_detected)

--- a/LocationAddress/kotlin/app/src/main/java/com/google/android/gms/location/sample/locationaddress/MainActivity.kt
+++ b/LocationAddress/kotlin/app/src/main/java/com/google/android/gms/location/sample/locationaddress/MainActivity.kt
@@ -88,7 +88,7 @@ class MainActivity : AppCompatActivity() {
     /**
      * The formatted location address.
      */
-    private var addressOutput = ""
+    private var addressOutput : String? = ""
 
     /**
      * Receiver registered with this activity to get the response from FetchAddressIntentService.

--- a/LocationUpdatesForegroundService/app/build.gradle
+++ b/LocationUpdatesForegroundService/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 'android-Q'
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.google.android.gms.location.sample.locationupdatesforegroundservice"
         minSdkVersion 16
-        targetSdkVersion 'Q'
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/LocationUpdatesPendingIntent/app/build.gradle
+++ b/LocationUpdatesPendingIntent/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 'android-Q'
+    compileSdkVersion 29
 
     defaultConfig {
         applicationId "com.google.android.gms.location.sample.locationupdatespendingintent"
         minSdkVersion 16
-        targetSdkVersion 'Q'
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Upon cloning the project from this repository and building in Android Studio we get the following errors and warning in couple of different files as shown in commits.

**1.** ERROR: Failed to find Platform SDK with path: platforms;android-Q (FIXED)
**2.** ERROR: Smart cast to 'Location' is impossible, because 'task.result' is a property that has open or 
custom getter (FIXED)
**3.** WARNING: Type mismatch: inferred type is String? but String was expected (FIXED)

After fixing these issues the project build successfully and sample apps were tested in emulator and they were running properly.